### PR TITLE
Allow relations with multiple services

### DIFF
--- a/reactive/redis.py
+++ b/reactive/redis.py
@@ -68,11 +68,10 @@ def set_redis_version():
     else:
         status_set('blocked', "Cannot get redis-server version")
 
+
 @when('redis.connected', 'redis.ready', 'redis.version.set')
-@when_not('redis.data.set', 'redis.configured')
 def set_relational_data(redis):
     if config('password'):
         redis.configure(port=config('port'), password=config('password'))
     else:
         redis.configure(port=config('port'))
-    set_state('redis.data.set')


### PR DESCRIPTION
The redis charm could only connect to one service. And if that relation was removed and remade, the relating charm would never get into a connected state. By removing the when_not conditions, one can redo a relation or relate multiple services.